### PR TITLE
Changed Array#sort_by to Array#shuffle for speed. 

### DIFF
--- a/lib/resque/plugins/fairly.rb
+++ b/lib/resque/plugins/fairly.rb
@@ -10,7 +10,7 @@ module Resque::Plugins
     # starved.  Workers will process queues in a random order each
     # time the poll for new work.
     def queues_randomly_ordered
-      queues_alpha_ordered.sort_by{rand}
+      queues_alpha_ordered.shuffle
     end
 
     def self.included(klass)


### PR DESCRIPTION
Depending on the ruby and array size, shuffle can be between 0.9 and 1.5s faster in my benchmarks. Makes sense - the implementation is in C, rather than ruby.

Given how often this method could run (and is running in my case), speed counts.
